### PR TITLE
[WIP]Add cpuid hypervisor identifier

### DIFF
--- a/MdePkg/Include/Register/Intel/Cpuid.h
+++ b/MdePkg/Include/Register/Intel/Cpuid.h
@@ -322,9 +322,9 @@ typedef union {
     ///
     UINT32  RDRAND:1;
     ///
-    /// [Bit 31] Always returns 0.
+/// [Bit 31] Indicate whether we are under visualization.
     ///
-    UINT32  NotUsed:1;
+    UINT32  HYPERVISOR:1;
   } Bits;
   ///
   /// All bit fields as a 32-bit value


### PR DESCRIPTION
acidanthera/bugtracker#523
For some reason that some msr not impletement in such hypervisor (QEMU/KVM/VMWare)
so some logic may not work fine in a VM.
This commit will add cpuid hypervisor support to indicate whether we are
under visualization, then we do some tricks to make it work.