### PR TITLE
UefiPayloadPkg: Fix compilation issues

### DIFF
--- a/UefiPayloadPkg/BlSupportSmm/BlSupportSmm.h
+++ b/UefiPayloadPkg/BlSupportSmm/BlSupportSmm.h
@@ -21,7 +21,7 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #include <Library/PciLib.h>
 #include <Protocol/SmmSwDispatch2.h>
 #include <Protocol/SmmAccess2.h>
-#include <protocol/MpService.h>
+#include <Protocol/MpService.h>
 #include <Library/UefiBootServicesTableLib.h>
 #include <Register/Intel/ArchitecturalMsr.h>
 #include <Guid/SmmRegisterInfoGuid.h>

--- a/UefiPayloadPkg/UefiPayloadPkg.dsc
+++ b/UefiPayloadPkg/UefiPayloadPkg.dsc
@@ -370,7 +370,9 @@
 [PcdsPatchableInModule.X64]
   gPcAtChipsetPkgTokenSpaceGuid.PcdRtcIndexRegister|$(RTC_INDEX_REGISTER)
   gPcAtChipsetPkgTokenSpaceGuid.PcdRtcTargetRegister|$(RTC_TARGET_REGISTER)
+!if $(SHELL_TYPE) == BUILD_SHELL || $(NETWORK_DRIVER_ENABLE) == TRUE
   gEfiNetworkPkgTokenSpaceGuid.PcdAllowHttpConnections|TRUE
+!endif
 
 [PcdsPatchableInModule.common]
   gEfiMdeModulePkgTokenSpaceGuid.PcdBootManagerMenuFile|{ 0x21, 0xaa, 0x2c, 0x46, 0x14, 0x76, 0x03, 0x45, 0x83, 0x6e, 0x8a, 0xb6, 0xf4, 0x66, 0x23, 0x31 }


### PR DESCRIPTION
Fixed several compilation issues in UefiPayloadPkg. 

1) When build package with Smm support, it results in:
 ```UDK/UefiPayloadPkg/BlSupportSmm/BlSupportSmm.h:24:10: error: non-portable path to file '<Protocol/MpService.h>'; specified path differs in case from file name on disk [-Werror,-Wnonportable-include-path]```
2) Additional condition added for gEfiNetworkPkgTokenSpaceGuid, which prevents compilation error when SHELL_TYPE differ from BUILD_SHELL, due to missing NetworkPkg/NetworkLibs.dsc.inc

Signed-off-by: Savva Mitrofanov <savvamtr@gmail.com>
Reviewed-by: Vitaly Cheptsov <cheptsov@ispras.ru>