### PR TITLE
UefiPayloadPkg: BlSupportSmm: Add missing EFIAPI modifiers

### DIFF
--- a/UefiPayloadPkg/BlSupportSmm/BlSupportSmm.c
+++ b/UefiPayloadPkg/BlSupportSmm/BlSupportSmm.c
@@ -189,6 +189,7 @@ SmmFeatureLockOnS3 (
   @param[in] ProcedureArgument  Pointer to SMRR_BASE_MASK structure.
 **/
 VOID
+EFIAPI
 SetSmrr (
   IN VOID                   *ProcedureArgument
   )


### PR DESCRIPTION
Added missing EFIAPI modifier to SetSmrr procedure which passed into gSmst->SmmStartupThisAp routine.

Signed-off-by: Savva Mitrofanov <sk.mitrofanov@ispras.ru>
Reviewed-by: Vitaly Cheptsov <cheptsov@ispras.ru>