### PR TITLE
UefiPayloadPkg/PchSmiDispatchSmm: Add missing EFIAPI modifiers

### DIFF
--- a/UefiPayloadPkg/PchSmiDispatchSmm/PchSmiDispatchSmm.c
+++ b/UefiPayloadPkg/PchSmiDispatchSmm/PchSmiDispatchSmm.c
@@ -85,6 +85,7 @@ FindContextByDispatchHandle (
 
 **/
 EFI_STATUS
+EFIAPI
 SmmSwDispatcher (
   IN     EFI_HANDLE               DispatchHandle,
   IN     CONST VOID               *RegisterContext,
@@ -435,7 +436,7 @@ PchSmiDispatchEntryPoint (
   //
   // Register a SMM handler to handle subsequent SW SMIs.
   //
-  Status = gSmst->SmiHandlerRegister ((EFI_MM_HANDLER_ENTRY_POINT)SmmSwDispatcher, NULL, &DispatchHandle);
+  Status = gSmst->SmiHandlerRegister (SmmSwDispatcher, NULL, &DispatchHandle);
   ASSERT_EFI_ERROR (Status);
 
   //


### PR DESCRIPTION
Added missing EFIAPI modifier to SmmSwDispatcher function which passed into gSmst->SmiHandlerRegister routine.

Signed-off-by: Savva Mitrofanov <sk.mitrofanov@ispras.ru>
Reviewed-by: Vitaly Cheptsov <cheptsov@ispras.ru>