### PR TITLE
SecurePE: README: Minor wording updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This branch demonstrates the integration of a new PE/COFF loader designed with t
 
 ## Introduction
 
-The PE/COFF loader is one of the central components of the firmware core and its trust base. Every Image part of an UEFI system, including platform drivers from the primary firmware storage, Option ROMs from external hardware, and OS loaders from arbitrary storage, is verified and loaded by this library. Clearly it is a key component to ensure platform reliability and software compatibility, and can only be modified with great care. It also is an essential component for security technologies such as Secure Boot and Measured Boot.
+The PE/COFF loader is one of the central components of the firmware core and its trust base. Every Image which is part of a UEFI system, including platform drivers from the primary firmware storage, Option ROMs from external hardware, and OS loaders from arbitrary storage, is verified and loaded by this library. Clearly it is a key component to ensure platform reliability and software compatibility, and can only be modified with great care. It also is an essential component for security technologies such as Secure Boot and Measured Boot.
 
 ![image](LoaderFlow.png)
 


### PR DESCRIPTION
Not sure, but if this file might be read by new-comers to the project needing convincing (e.g. via https://lkml.org/lkml/2022/8/1/1314) then the attached is two small changes which I found would make the first para. more smoothly readable, as native speaker.

To defend the usage of "a UEFI", based on the sound not the letter, see e.g. https://www.google.com/search?q=a+or+an+before+u+in+acronym .