### PR TITLE
GenSec: Support TianoCompress

### DIFF
--- a/BaseTools/Source/C/GenSec/GenSec.c
+++ b/BaseTools/Source/C/GenSec/GenSec.c
@@ -69,7 +69,7 @@ STATIC CHAR8      *mSectionTypeName[] = {
   "EFI_SECTION_SMM_DEPEX"               // 0x1C
 };
 
-STATIC CHAR8      *mCompressionTypeName[]    = { "PI_NONE", "PI_STD" };
+STATIC CHAR8      *mCompressionTypeName[]    = { "PI_NONE", "PI_STD", "TIANO" };
 
 #define EFI_GUIDED_SECTION_NONE 0x80
 STATIC CHAR8      *mGUIDedSectionAttribue[]  = { "NONE", "PROCESSING_REQUIRED", "AUTH_STATUS_VALID"};
@@ -169,7 +169,7 @@ Returns:
                         if -s option is not given, \n\
                         EFI_SECTION_ALL is default section type.\n");
   fprintf (stdout, "  -c [Type], --compress [Type]\n\
-                        Compress method type can be PI_NONE or PI_STD.\n\
+                        Compress method type can be PI_NONE, PI_STD or TIANO.\n\
                         if -c option is not given, PI_STD is default type.\n");
   fprintf (stdout, "  -g GuidValue, --vendor GuidValue\n\
                         GuidValue is one specific vendor guid value.\n\
@@ -708,6 +708,10 @@ Returns:
     CompressFunction = (COMPRESS_FUNCTION) EfiCompress;
     break;
 
+  case TIANO_COMPRESS:
+    CompressFunction = (COMPRESS_FUNCTION) TianoCompress;
+    break;
+
   default:
     Error (NULL, 0, 2000, "Invalid parameter", "unknown compression type");
     free (FileBuffer);
@@ -772,7 +776,7 @@ Returns:
     memset(CompressionSect2->CommonHeader.Size, 0xff, sizeof(UINT8) * 3);
     CompressionSect2->CommonHeader.Type         = EFI_SECTION_COMPRESSION;
     CompressionSect2->CommonHeader.ExtendedSize = TotalLength;
-    CompressionSect2->CompressionType           = SectCompSubType;
+    CompressionSect2->CompressionType           = (SectCompSubType == EFI_NOT_COMPRESSED) ? SectCompSubType : EFI_STANDARD_COMPRESSION;
     CompressionSect2->UncompressedLength        = InputLength;
   } else {
     CompressionSect = (EFI_COMPRESSION_SECTION *) FileBuffer;
@@ -781,7 +785,7 @@ Returns:
     CompressionSect->CommonHeader.Size[0]  = (UINT8) (TotalLength & 0xff);
     CompressionSect->CommonHeader.Size[1]  = (UINT8) ((TotalLength & 0xff00) >> 8);
     CompressionSect->CommonHeader.Size[2]  = (UINT8) ((TotalLength & 0xff0000) >> 16);
-    CompressionSect->CompressionType       = SectCompSubType;
+    CompressionSect->CompressionType       = (SectCompSubType == EFI_NOT_COMPRESSED) ? SectCompSubType : EFI_STANDARD_COMPRESSION;
     CompressionSect->UncompressedLength    = InputLength;
   }
 
@@ -1665,6 +1669,8 @@ Returns:
       SectCompSubType = EFI_NOT_COMPRESSED;
     } else if (stricmp (CompressionName, mCompressionTypeName[EFI_STANDARD_COMPRESSION]) == 0) {
       SectCompSubType = EFI_STANDARD_COMPRESSION;
+    } else if (stricmp (CompressionName, mCompressionTypeName[TIANO_COMPRESS]) == 0) {
+      SectCompSubType = TIANO_COMPRESS;
     } else {
       Error (NULL, 0, 1003, "Invalid option value", "--compress = %s", CompressionName);
       goto Finish;

--- a/BaseTools/Source/C/Include/Common/PiFirmwareFile.h
+++ b/BaseTools/Source/C/Include/Common/PiFirmwareFile.h
@@ -169,6 +169,7 @@ typedef EFI_COMMON_SECTION_HEADER2 EFI_COMPATIBILITY16_SECTION2;
 //
 #define EFI_NOT_COMPRESSED        0x00
 #define EFI_STANDARD_COMPRESSION  0x01
+#define TIANO_COMPRESS            0x02
 //
 // An encapsulation section type in which the
 // section data is compressed.

--- a/BaseTools/Source/Python/GenFds/CompressSection.py
+++ b/BaseTools/Source/Python/GenFds/CompressSection.py
@@ -26,7 +26,8 @@ class CompressSection (CompressSectionClassObject) :
     ## compress types: PI standard and non PI standard
     CompTypeDict = {
         'PI_STD'  : 'PI_STD',
-        'PI_NONE' : 'PI_NONE'
+        'PI_NONE' : 'PI_NONE',
+        'TIANO'   : 'TIANO',
     }
 
     ## The constructor

--- a/BaseTools/Source/Python/GenFds/FdfParser.py
+++ b/BaseTools/Source/Python/GenFds/FdfParser.py
@@ -2985,7 +2985,7 @@ class FdfParser:
 
         if self._IsKeyword("COMPRESS"):
             type = "PI_STD"
-            if self._IsKeyword("PI_STD") or self._IsKeyword("PI_NONE"):
+            if self._IsKeyword("PI_STD") or self._IsKeyword("PI_NONE") or self._IsKeyword("TIANO"):
                 type = self._Token
 
             if not self._IsToken("{"):
@@ -4054,7 +4054,7 @@ class FdfParser:
     def _GetRuleEncapsulationSection(self, theRule):
         if self._IsKeyword("COMPRESS"):
             Type = "PI_STD"
-            if self._IsKeyword("PI_STD") or self._IsKeyword("PI_NONE"):
+            if self._IsKeyword("PI_STD") or self._IsKeyword("PI_NONE") or self._IsKeyword("TIANO"):
                 Type = self._Token
 
             if not self._IsToken("{"):

--- a/BaseTools/UserManuals/GenSec_Utility_Man_Page.rtf
+++ b/BaseTools/UserManuals/GenSec_Utility_Man_Page.rtf
@@ -184,7 +184,7 @@ COMPAT16\cell \hich\af4\dbch\af31505\loch\f4 EFI_SECTION_COMPATIBILITY16\cell }\
 SSION, EFI_SECTION_GUID_DEFINED, EFI_SECTION_PE32, EFI_SECTION_PIC, EFI_SECTION_TE, EFI_SECTION_DXE_DEPEX, EFI_SECTION_COMPATIBILITY16, EFI_SECTION_USER_INTERFACE, EFI_SECTION_VERSION, EFI_SECTION_FIRMWARE_VOLUME_IMAGE, EFI_SECTION_RAW, EFI_SECTION_FREEFO
 \hich\af43\dbch\af31505\loch\f43 R\hich\af43\dbch\af31505\loch\f43 M_SUBTYPE_GUID, EFI_SECTION_PEI_DEPEX. If sectiontype is not given, EFI_SECTION_ALL is default type to contain the input all sections to one section file.
 \par }\pard \ltrpar\ql \li0\ri0\sb200\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\rtlch\fcs1 \ab\af43\afs18 \ltrch\fcs0 \b\fs18\cf1\insrsid11342878 \hich\af43\dbch\af31505\loch\f43 -c [Type], --compress [Type]
-\par }\pard \ltrpar\ql \li360\ri0\sb200\nowidctlpar\wrapdefault\faauto\rin0\lin360\itap0 {\rtlch\fcs1 \af43\afs18 \ltrch\fcs0 \fs18\cf1\insrsid11342878 \hich\af43\dbch\af31505\loch\f43 Compress method type can be PI_NONE or PI_STD. If Type is not given, PI_
+\par }\pard \ltrpar\ql \li360\ri0\sb200\nowidctlpar\wrapdefault\faauto\rin0\lin360\itap0 {\rtlch\fcs1 \af43\afs18 \ltrch\fcs0 \fs18\cf1\insrsid11342878 \hich\af43\dbch\af31505\loch\f43 Compress method type can be PI_NONE, PI_STD or TIANO. If Type is not given, PI_
 \hich\af43\dbch\af31505\loch\f43 STD is default type.
 \par }\pard \ltrpar\ql \li0\ri0\sb200\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\rtlch\fcs1 \ab\af43\afs18 \ltrch\fcs0 \b\fs18\cf1\insrsid11342878 \hich\af43\dbch\af31505\loch\f43 -g GuidValue, --vendor GuidValue
 \par }\pard \ltrpar\ql \li360\ri0\sb200\nowidctlpar\wrapdefault\faauto\rin0\lin360\itap0 {\rtlch\fcs1 \af43\afs18 \ltrch\fcs0 \fs18\cf1\insrsid11342878 \hich\af43\dbch\af31505\loch\f43 


### PR DESCRIPTION
Allows .fdf files to define a compressed .ffs section which can be read by legacy EFI firmware (such as found on Apple Mac). Use `COMPRESS TIANO`.