### PR TITLE
FatPkg: Implements read-only mode support

### DIFF
--- a/FatPkg/EnhancedFatDxe/Delete.c
+++ b/FatPkg/EnhancedFatDxe/Delete.c
@@ -31,6 +31,10 @@ FatDelete (
   EFI_STATUS  Status;
   UINTN       Round;
 
+  if (FeaturePcdGet (PcdFatReadOnlyMode)) {
+    return EFI_WRITE_PROTECTED;
+  }
+
   IFile = IFILE_FROM_FHAND (FHand);
   OFile = IFile->OFile;
 

--- a/FatPkg/EnhancedFatDxe/DirectoryManage.c
+++ b/FatPkg/EnhancedFatDxe/DirectoryManage.c
@@ -73,6 +73,10 @@ FatStoreDirEnt (
   UINT8              EntryCount;
   UINT8              LfnOrdinal;
 
+  if (FeaturePcdGet (PcdFatReadOnlyMode)) {
+    return EFI_WRITE_PROTECTED;
+  }
+
   EntryPos   = DirEnt->EntryPos;
   EntryCount = DirEnt->EntryCount;
   //
@@ -709,6 +713,9 @@ FatExpandODir (
   IN FAT_OFILE  *OFile
   )
 {
+  if (FeaturePcdGet (PcdFatReadOnlyMode)) {
+    return EFI_WRITE_PROTECTED;
+  }
   return FatExpandOFile (OFile, OFile->FileSize + OFile->Volume->ClusterSize);
 }
 
@@ -954,6 +961,10 @@ FatSetVolumeEntry (
   FAT_DIRENT  LabelDirEnt;
   FAT_OFILE   *Root;
 
+  if (FeaturePcdGet (PcdFatReadOnlyMode)) {
+    return EFI_WRITE_PROTECTED;
+  }
+
   Root   = Volume->Root;
   Status = FatSeekVolumeId (Volume->Root, &LabelDirEnt);
   if (EFI_ERROR (Status)) {
@@ -1001,6 +1012,10 @@ FatCreateDotDirEnts (
   EFI_STATUS  Status;
   FAT_DIRENT  *DirEnt;
 
+  if (FeaturePcdGet (PcdFatReadOnlyMode)) {
+    return EFI_WRITE_PROTECTED;
+  }
+
   Status = FatExpandODir (OFile);
   if (EFI_ERROR (Status)) {
     return Status;
@@ -1047,6 +1062,10 @@ FatCreateDirEnt (
   FAT_DIRENT  *DirEnt;
   FAT_ODIR    *ODir;
   EFI_STATUS  Status;
+
+  if (FeaturePcdGet (PcdFatReadOnlyMode)) {
+    return EFI_WRITE_PROTECTED;
+  }
 
   ASSERT (OFile != NULL);
   ODir = OFile->ODir;
@@ -1104,6 +1123,10 @@ FatRemoveDirEnt (
   )
 {
   FAT_ODIR  *ODir;
+
+  if (FeaturePcdGet (PcdFatReadOnlyMode)) {
+    return EFI_WRITE_PROTECTED;
+  }
 
   ODir = OFile->ODir;
   if (ODir->CurrentCursor == &DirEnt->Link) {

--- a/FatPkg/EnhancedFatDxe/Fat.inf
+++ b/FatPkg/EnhancedFatDxe/Fat.inf
@@ -56,6 +56,7 @@
 
 [Packages]
   MdePkg/MdePkg.dec
+  FatPkg/FatPkg.dec
 
 [LibraryClasses]
   UefiRuntimeServicesTableLib
@@ -82,6 +83,7 @@
   gEfiUnicodeCollation2ProtocolGuid     ## TO_START
 
 [Pcd]
+  gEfiFatPkgTokenSpaceGuid.PcdFatReadOnlyMode                   ## CONSUMES
   gEfiMdePkgTokenSpaceGuid.PcdUefiVariableDefaultLang           ## SOMETIMES_CONSUMES
   gEfiMdePkgTokenSpaceGuid.PcdUefiVariableDefaultPlatformLang   ## SOMETIMES_CONSUMES
 [UserExtensions.TianoCore."ExtraFiles"]

--- a/FatPkg/EnhancedFatDxe/FileSpace.c
+++ b/FatPkg/EnhancedFatDxe/FileSpace.c
@@ -362,6 +362,10 @@ FatShrinkEof (
   UINTN       Cluster;
   UINTN       LastCluster;
 
+  if (FeaturePcdGet (PcdFatReadOnlyMode)) {
+    return EFI_WRITE_PROTECTED;
+  }
+
   Volume = OFile->Volume;
   ASSERT_VOLUME_LOCKED (Volume);
 
@@ -439,6 +443,10 @@ FatGrowEof (
   UINTN       LastCluster;
   UINTN       NewCluster;
   UINTN       ClusterCount;
+
+  if (FeaturePcdGet (PcdFatReadOnlyMode)) {
+    return EFI_WRITE_PROTECTED;
+  }
 
   //
   // For FAT file system, the max file is 4GB.

--- a/FatPkg/EnhancedFatDxe/Flush.c
+++ b/FatPkg/EnhancedFatDxe/Flush.c
@@ -35,6 +35,10 @@ FatFlushEx (
   EFI_STATUS  Status;
   FAT_TASK    *Task;
 
+  if (FeaturePcdGet (PcdFatReadOnlyMode)) {
+    return EFI_WRITE_PROTECTED;
+  }
+
   IFile  = IFILE_FROM_FHAND (FHand);
   OFile  = IFile->OFile;
   Volume = OFile->Volume;
@@ -112,6 +116,9 @@ FatFlush (
   IN EFI_FILE_PROTOCOL  *FHand
   )
 {
+  if (FeaturePcdGet (PcdFatReadOnlyMode)) {
+    return EFI_WRITE_PROTECTED;
+  }
   return FatFlushEx (FHand, NULL);
 }
 

--- a/FatPkg/EnhancedFatDxe/Init.c
+++ b/FatPkg/EnhancedFatDxe/Init.c
@@ -51,7 +51,7 @@ FatAllocateVolume (
   Volume->DiskIo2                    = DiskIo2;
   Volume->BlockIo                    = BlockIo;
   Volume->MediaId                    = BlockIo->Media->MediaId;
-  Volume->ReadOnly                   = BlockIo->Media->ReadOnly;
+  Volume->ReadOnly                   = BlockIo->Media->ReadOnly || FeaturePcdGet (PcdFatReadOnlyMode);
   Volume->VolumeInterface.Revision   = EFI_SIMPLE_FILE_SYSTEM_PROTOCOL_REVISION;
   Volume->VolumeInterface.OpenVolume = FatOpenVolume;
   InitializeListHead (&Volume->CheckRef);

--- a/FatPkg/EnhancedFatDxe/Open.c
+++ b/FatPkg/EnhancedFatDxe/Open.c
@@ -224,8 +224,12 @@ FatOpenEx (
   //
   switch (OpenMode) {
     case EFI_FILE_MODE_READ:
+      break;
     case EFI_FILE_MODE_READ | EFI_FILE_MODE_WRITE:
     case EFI_FILE_MODE_READ | EFI_FILE_MODE_WRITE | EFI_FILE_MODE_CREATE:
+      if (FeaturePcdGet (PcdFatReadOnlyMode)) {
+        return EFI_WRITE_PROTECTED;
+      }
       break;
 
     default:

--- a/FatPkg/EnhancedFatDxe/ReadWrite.c
+++ b/FatPkg/EnhancedFatDxe/ReadWrite.c
@@ -211,6 +211,10 @@ FatIFileAccess (
   UINT64      EndPosition;
   FAT_TASK    *Task;
 
+  if (FeaturePcdGet (PcdFatReadOnlyMode) && IoMode == WriteData) {
+    return EFI_WRITE_PROTECTED;
+  }
+
   IFile  = IFILE_FROM_FHAND (FHand);
   OFile  = IFile->OFile;
   Volume = OFile->Volume;
@@ -414,6 +418,9 @@ FatWrite (
   IN     VOID               *Buffer
   )
 {
+  if (FeaturePcdGet (PcdFatReadOnlyMode)) {
+    return EFI_WRITE_PROTECTED;
+  }
   return FatIFileAccess (FHand, WriteData, BufferSize, Buffer, NULL);
 }
 
@@ -437,6 +444,9 @@ FatWriteEx (
   IN OUT EFI_FILE_IO_TOKEN  *Token
   )
 {
+  if (FeaturePcdGet (PcdFatReadOnlyMode)) {
+    return EFI_WRITE_PROTECTED;
+  }
   return FatIFileAccess (FHand, WriteData, &Token->BufferSize, Token->Buffer, Token);
 }
 
@@ -470,6 +480,10 @@ FatAccessOFile (
   UINTN       Len;
   EFI_STATUS  Status;
   UINTN       BufferSize;
+
+  if (FeaturePcdGet (PcdFatReadOnlyMode) && IoMode == WriteData) {
+    return EFI_WRITE_PROTECTED;
+  }
 
   BufferSize = *DataBufferSize;
   Volume     = OFile->Volume;
@@ -542,6 +556,10 @@ FatExpandOFile (
   EFI_STATUS  Status;
   UINTN       WritePos;
 
+  if (FeaturePcdGet (PcdFatReadOnlyMode)) {
+    return EFI_WRITE_PROTECTED;
+  }
+
   WritePos = OFile->FileSize;
   Status   = FatGrowEof (OFile, ExpandedSize);
   if (!EFI_ERROR (Status)) {
@@ -574,6 +592,10 @@ FatWriteZeroPool (
   UINTN       AppendedSize;
   UINTN       BufferSize;
   UINTN       WriteSize;
+
+  if (FeaturePcdGet (PcdFatReadOnlyMode)) {
+    return EFI_WRITE_PROTECTED;
+  }
 
   AppendedSize = OFile->FileSize - WritePos;
   BufferSize   = AppendedSize;
@@ -624,6 +646,10 @@ FatTruncateOFile (
   IN UINTN      TruncatedSize
   )
 {
+  if (FeaturePcdGet (PcdFatReadOnlyMode)) {
+    return EFI_WRITE_PROTECTED;
+  }
+
   OFile->FileSize = TruncatedSize;
   return FatShrinkEof (OFile);
 }

--- a/FatPkg/FatPkg.dec
+++ b/FatPkg/FatPkg.dec
@@ -17,3 +17,16 @@
 
 [UserExtensions.TianoCore."ExtraFiles"]
   FatPkgExtra.uni
+
+[Guids]
+  #
+  # GUID defined in package
+  #
+  gEfiFatPkgTokenSpaceGuid = { 0xbe1f59ff, 0x65f5, 0x4b28, {0xb2, 0x8d, 0x56, 0x85, 0x36, 0x4a, 0xb1, 0xd2 } }
+
+[PcdsFeatureFlag.common]
+  ## Indicates if driver is in read-only mode.<BR><BR>
+  #   TRUE  - Restricts write operations.<BR>
+  #   FALSE - Write operations allowed. Default behavior<BR>
+  # @Prompt Disables write operations on fat filesystem.
+  gEfiFatPkgTokenSpaceGuid.PcdFatReadOnlyMode |FALSE|BOOLEAN|0x00000001

--- a/FatPkg/FatPkg.dsc
+++ b/FatPkg/FatPkg.dsc
@@ -82,3 +82,6 @@
 [Components]
   FatPkg/FatPei/FatPei.inf
   FatPkg/EnhancedFatDxe/Fat.inf
+
+[PcdsFeatureFlag]
+  gEfiFatPkgTokenSpaceGuid.PcdFatReadOnlyMode|FALSE


### PR DESCRIPTION
This set of commits implements `gEfiFatPkgTokenSpaceGuid` and PcdsFeatureFlag `PcdFatReadOnlyMode` in FatPkg, which allows you to force read-only mode.