### PR TITLE
SecurityPkg: Remove reference to deleted variable

### DIFF
--- a/SecurityPkg/Library/DxeImageVerificationLib/DxeImageVerificationLib.c
+++ b/SecurityPkg/Library/DxeImageVerificationLib/DxeImageVerificationLib.c
@@ -1611,7 +1611,7 @@ DxeImageVerificationHandler (
         IsVerified = TRUE;
       } else {
         Action = EFI_IMAGE_EXECUTION_AUTH_SIG_NOT_FOUND;
-        DEBUG ((DEBUG_INFO, "DxeImageVerificationLib: Image is signed but signature is not allowed by DB and %s hash of image is not found in DB/DBX.\n", mHashTypeStr));
+        DEBUG ((DEBUG_INFO, "DxeImageVerificationLib: Image is signed but signature is not allowed by DB and hash of image is not found in DB/DBX.\n"));
       }
     }
   }


### PR DESCRIPTION
Should have been removed in 9e5601b1f45048d9d8f7b5a3f260bc6850c0e1a2

Breaks OVMF secure boot build `./build.sh -a X64 -b RELEASE -D SECURE_BOOT_ENABLE=TRUE`, works fine with fix.