### PR TITLE
MdeModulePkg: Remove ASSERT which prevents VOLUME_CORRUPTED image status from being returned

### DIFF
--- a/MdeModulePkg/Core/Dxe/Image/Image.c
+++ b/MdeModulePkg/Core/Dxe/Image/Image.c
@@ -1203,7 +1203,6 @@ CoreLoadImageCommon (
              ImageIsFromFv
              );
   if (EFI_ERROR (Status)) {
-    ASSERT (FALSE);
     return Status;
   }
 


### PR DESCRIPTION
When DEBUG_RAISE is disabled then PeCoffInitializeContext within BasePeCoffLib2 will return VOLUME_CORRUPTED for certain image errors. These errors then hit the ASSERT removed by this PR. Without it these status codes pass back out of gBS->LoadImage in DEBUG builds, as desired.