### PR TITLE
MdePkg: Convert new normal debug info to separate struct

### DIFF
--- a/ArmPkg/Library/DefaultExceptionHandlerLib/DefaultExceptionHandlerUefi.c
+++ b/ArmPkg/Library/DefaultExceptionHandlerLib/DefaultExceptionHandlerUefi.c
@@ -50,16 +50,16 @@ GetImageName (
 
   Address = (CHAR8 *)(UINTN)FaultAddress;
   for (Entry = 0; Entry < DebugTableHeader->TableSize; Entry++, DebugTable++) {
-    if (DebugTable->NormalImage != NULL) {
-      if ((DebugTable->NormalImage->ImageInfoType == EFI_DEBUG_IMAGE_INFO_TYPE_NORMAL) &&
-          (DebugTable->NormalImage->LoadedImageProtocolInstance != NULL))
+    if (DebugTable->NormalImage2 != NULL) {
+      if ((DebugTable->NormalImage2->ImageInfoType == EFI_DEBUG_IMAGE_INFO_TYPE_NORMAL2) &&
+          (DebugTable->NormalImage2->LoadedImageProtocolInstance != NULL))
       {
-        if ((Address >= (CHAR8 *)DebugTable->NormalImage->LoadedImageProtocolInstance->ImageBase) &&
-            (Address <= ((CHAR8 *)DebugTable->NormalImage->LoadedImageProtocolInstance->ImageBase + DebugTable->NormalImage->LoadedImageProtocolInstance->ImageSize)))
+        if ((Address >= (CHAR8 *)DebugTable->NormalImage2->LoadedImageProtocolInstance->ImageBase) &&
+            (Address <= ((CHAR8 *)DebugTable->NormalImage2->LoadedImageProtocolInstance->ImageBase + DebugTable->NormalImage2->LoadedImageProtocolInstance->ImageSize)))
         {
-          *ImageBase           = (UINTN)DebugTable->NormalImage->LoadedImageProtocolInstance->ImageBase;
-          *DebugBase           = (UINTN)DebugTable->NormalImage->DebugBase;
-          return DebugTable->NormalImage->PdbPath;
+          *ImageBase           = (UINTN)DebugTable->NormalImage2->LoadedImageProtocolInstance->ImageBase;
+          *DebugBase           = (UINTN)DebugTable->NormalImage2->DebugBase;
+          return DebugTable->NormalImage2->PdbPath;
         }
       }
     }

--- a/BaseTools/ImageTool/PeEmit.c
+++ b/BaseTools/ImageTool/PeEmit.c
@@ -32,12 +32,12 @@ typedef struct {
   EFI_IMAGE_DEBUG_CODEVIEW_NB10_ENTRY  Nb10;
 } image_tool_debug_dir_t;
 
-#define SIZE_OF_DATA_DIRECRORY  \
+#define SIZE_OF_DATA_DIRECTORY  \
   EFI_IMAGE_NUMBER_OF_DIRECTORY_ENTRIES * sizeof (EFI_IMAGE_DATA_DIRECTORY)
 
 #define SIZE_OF_OPTIONAL_HEADER                                             \
   sizeof (EFI_IMAGE_NT_HEADERS) - sizeof (EFI_IMAGE_NT_HEADERS_COMMON_HDR)  \
-    + SIZE_OF_DATA_DIRECRORY
+    + SIZE_OF_DATA_DIRECTORY
 
 static
 bool
@@ -583,7 +583,7 @@ ToolImageEmitPeFile (
     return false;
   }
 
-  SectionHeadersOffset = sizeof (*PeHdr) + SIZE_OF_DATA_DIRECRORY;
+  SectionHeadersOffset = sizeof (*PeHdr) + SIZE_OF_DATA_DIRECTORY;
   SectionHeadersSize   = NumSections * sizeof (EFI_IMAGE_SECTION_HEADER);
   SizeOfPeHeaders      = SectionHeadersOffset + SectionHeadersSize;
   SizeOfHeaders        = sizeof (mDosHdr) + SizeOfPeHeaders;

--- a/BaseTools/ImageTool/UeEmit.c
+++ b/BaseTools/ImageTool/UeEmit.c
@@ -598,7 +598,7 @@ ToolImageEmitUeDebugTable (
   )
 {
   UE_DEBUG_TABLE   DebugTable;
-  uint8_t          SymOffsetFactor;
+  uint8_t          SymSubtrahendFactor;
   uint32_t         DebugTableOffset;
   uint32_t         DebugTableSize;
   uint16_t         Index;
@@ -609,14 +609,14 @@ ToolImageEmitUeDebugTable (
   assert (Image->DebugInfo.SymbolsPathLen <= MAX_UINT8);
   assert (IS_ALIGNED (BaseAddressSubtrahend, Image->SegmentInfo.SegmentAlignment));
 
-  SymOffsetFactor = (uint8_t)(BaseAddressSubtrahend / Image->SegmentInfo.SegmentAlignment);
-  if (SymOffsetFactor > 0x03) {
+  SymSubtrahendFactor = (uint8_t)(BaseAddressSubtrahend / Image->SegmentInfo.SegmentAlignment);
+  if (SymSubtrahendFactor > 0x03) {
     DEBUG_RAISE ();
     return false;
   }
 
-  DebugTable.ImageInfo = SymOffsetFactor;
-  assert (UE_DEBUG_TABLE_IMAGE_INFO_SYM_OFFSET_FACTOR (DebugTable.ImageInfo) == SymOffsetFactor);
+  DebugTable.ImageInfo = SymSubtrahendFactor;
+  assert (UE_DEBUG_TABLE_IMAGE_INFO_SYM_SUBTRAHEND_FACTOR (DebugTable.ImageInfo) == SymSubtrahendFactor);
   assert ((DebugTable.ImageInfo & 0xFCU) == 0);
 
   DebugTable.SymbolsPathLength = (uint8_t)Image->DebugInfo.SymbolsPathLen;

--- a/EmbeddedPkg/GdbStub/GdbStub.c
+++ b/EmbeddedPkg/GdbStub/GdbStub.c
@@ -873,10 +873,10 @@ QxferLibrary (
 
   if (gDebugTable != NULL) {
     for ( ; gEfiDebugImageTableEntry < gDebugImageTableHeader->TableSize; gEfiDebugImageTableEntry++, gDebugTable++) {
-      if (gDebugTable->NormalImage != NULL) {
-        if ((gDebugTable->NormalImage->ImageInfoType == EFI_DEBUG_IMAGE_INFO_TYPE_NORMAL) &&
-            (gDebugTable->NormalImage->LoadedImageProtocolInstance != NULL)) {
-          Pdb = gDebugTable->NormalImage->PdbPath;
+      if (gDebugTable->NormalImage2 != NULL) {
+        if ((gDebugTable->NormalImage2->ImageInfoType == EFI_DEBUG_IMAGE_INFO_TYPE_NORMAL2) &&
+            (gDebugTable->NormalImage2->LoadedImageProtocolInstance != NULL)) {
+          Pdb = gDebugTable->NormalImage2->PdbPath;
           if (Pdb != NULL) {
             Size = AsciiSPrint (
                      gXferLibraryBuffer,

--- a/MdeModulePkg/Core/Dxe/DxeMain.h
+++ b/MdeModulePkg/Core/Dxe/DxeMain.h
@@ -2367,20 +2367,19 @@ CoreUpdateDebugTableCrc32 (
 
 /**
   Adds a new DebugImageInfo structure to the DebugImageInfo Table.  Re-Allocates
-  the table if it's not large enough to accomidate another entry.
+  the table if it's not large enough to accommodate another entry.
 
-  @param  ImageInfoType  type of debug image information
   @param  LoadedImage    pointer to the loaded image protocol for the image being
                          loaded
   @param  ImageHandle    image handle for the image being loaded
+  @param  ImageContext   image context for the image being loaded
 
 **/
 VOID
 CoreNewDebugImageInfoEntry (
-  IN  UINT32                     ImageInfoType,
-  IN  EFI_LOADED_IMAGE_PROTOCOL  *LoadedImage,
-  IN  EFI_HANDLE                 ImageHandle,
-  IN  UEFI_IMAGE_LOADER_IMAGE_CONTEXT  *ImageContext
+  IN       EFI_LOADED_IMAGE_PROTOCOL        *LoadedImage,
+  IN       EFI_HANDLE                       ImageHandle,
+  IN CONST UEFI_IMAGE_LOADER_IMAGE_CONTEXT  *ImageContext
   );
 
 /**

--- a/MdeModulePkg/Core/Dxe/DxeMain/DxeMain.c
+++ b/MdeModulePkg/Core/Dxe/DxeMain/DxeMain.c
@@ -389,7 +389,6 @@ DxeMain (
   //
   CoreInitializeDebugImageInfoTable ();
   CoreNewDebugImageInfoEntry (
-    EFI_DEBUG_IMAGE_INFO_TYPE_NORMAL,
     gDxeCoreLoadedImage,
     gImageHandle,
     &ImageContext

--- a/MdeModulePkg/Core/Dxe/Image/Image.c
+++ b/MdeModulePkg/Core/Dxe/Image/Image.c
@@ -1385,7 +1385,7 @@ CoreLoadImageCommon (
   // Register the image in the Debug Image Info Table if the attribute is set
   //
   if ((Attribute & EFI_LOAD_PE_IMAGE_ATTRIBUTE_DEBUG_IMAGE_INFO_TABLE_REGISTRATION) != 0) {
-    CoreNewDebugImageInfoEntry (EFI_DEBUG_IMAGE_INFO_TYPE_NORMAL, &Image->Info, Image->Handle, &ImageContext);
+    CoreNewDebugImageInfoEntry (&Image->Info, Image->Handle, &ImageContext);
   }
 
   //

--- a/MdeModulePkg/Core/Dxe/Misc/DebugImageInfo.c
+++ b/MdeModulePkg/Core/Dxe/Misc/DebugImageInfo.c
@@ -150,30 +150,29 @@ CoreUpdateDebugTableCrc32 (
 
 /**
   Adds a new DebugImageInfo structure to the DebugImageInfo Table.  Re-Allocates
-  the table if it's not large enough to accomidate another entry.
+  the table if it's not large enough to accommodate another entry.
 
-  @param  ImageInfoType  type of debug image information
   @param  LoadedImage    pointer to the loaded image protocol for the image being
                          loaded
   @param  ImageHandle    image handle for the image being loaded
+  @param  ImageContext   image context for the image being loaded
 
 **/
 VOID
 CoreNewDebugImageInfoEntry (
-  IN     UINT32                           ImageInfoType,
-  IN     EFI_LOADED_IMAGE_PROTOCOL        *LoadedImage,
-  IN     EFI_HANDLE                       ImageHandle,
-  IN OUT UEFI_IMAGE_LOADER_IMAGE_CONTEXT  *ImageContext
+  IN       EFI_LOADED_IMAGE_PROTOCOL        *LoadedImage,
+  IN       EFI_HANDLE                       ImageHandle,
+  IN CONST UEFI_IMAGE_LOADER_IMAGE_CONTEXT  *ImageContext
   )
 {
-  EFI_DEBUG_IMAGE_INFO        *Table;
-  EFI_DEBUG_IMAGE_INFO        *NewTable;
-  UINTN                       Index;
-  UINTN                       TableSize;
-  EFI_DEBUG_IMAGE_INFO_NORMAL *NormalImage;
-  RETURN_STATUS               Status;
-  CONST CHAR8                 *PdbPath;
-  UINT32                      PdbPathSize;
+  EFI_DEBUG_IMAGE_INFO          *Table;
+  EFI_DEBUG_IMAGE_INFO          *NewTable;
+  UINTN                         Index;
+  UINTN                         TableSize;
+  EFI_DEBUG_IMAGE_INFO_NORMAL2  *NormalImage2;
+  RETURN_STATUS                 Status;
+  CONST CHAR8                   *PdbPath;
+  UINT32                        PdbPathSize;
 
   //
   // Set the flag indicating that we're in the process of updating the table.
@@ -187,7 +186,7 @@ CoreNewDebugImageInfoEntry (
     // We still have empty entires in the Table, find the first empty entry.
     //
     Index = 0;
-    while (Table[Index].NormalImage != NULL) {
+    while (Table[Index].NormalImage2 != NULL) {
       Index++;
     }
 
@@ -232,26 +231,26 @@ CoreNewDebugImageInfoEntry (
   //
   // Allocate data for new entry
   //
-  NormalImage = AllocateZeroPool (sizeof (EFI_DEBUG_IMAGE_INFO_NORMAL));
-  if (NormalImage != NULL) {
+  NormalImage2 = AllocateZeroPool (sizeof (EFI_DEBUG_IMAGE_INFO_NORMAL2));
+  if (NormalImage2 != NULL) {
     //
     // Update the entry
     //
-    NormalImage->ImageInfoType               = (UINT32)ImageInfoType;
-    NormalImage->LoadedImageProtocolInstance = LoadedImage;
-    NormalImage->ImageHandle                 = ImageHandle;
+    NormalImage2->ImageInfoType               = EFI_DEBUG_IMAGE_INFO_TYPE_NORMAL2;
+    NormalImage2->LoadedImageProtocolInstance = LoadedImage;
+    NormalImage2->ImageHandle                 = ImageHandle;
 
     Status = UefiImageGetSymbolsPath (ImageContext, &PdbPath, &PdbPathSize);
     if (!RETURN_ERROR (Status)) {
-      NormalImage->PdbPath = AllocateCopyPool (PdbPathSize, PdbPath);
+      NormalImage2->PdbPath = AllocateCopyPool (PdbPathSize, PdbPath);
     }
 
-    NormalImage->DebugBase = UefiImageLoaderGetDebugAddress (ImageContext);
+    NormalImage2->DebugBase = UefiImageLoaderGetDebugAddress (ImageContext);
     //
     // Increase the number of EFI_DEBUG_IMAGE_INFO elements and set the mDebugInfoTable in modified status.
     //
     mDebugInfoTableHeader.UpdateStatus |= EFI_DEBUG_IMAGE_INFO_TABLE_MODIFIED;
-    Table[Index].NormalImage = NormalImage;
+    Table[Index].NormalImage2 = NormalImage2;
     mDebugInfoTableHeader.TableSize++;
   }
 
@@ -269,34 +268,42 @@ CoreRemoveDebugImageInfoEntry (
   EFI_HANDLE  ImageHandle
   )
 {
-  EFI_DEBUG_IMAGE_INFO        *Table;
-  UINTN                       Index;
-  EFI_DEBUG_IMAGE_INFO_NORMAL *NormalImage;
+  EFI_DEBUG_IMAGE_INFO          *Table;
+  UINTN                         Index;
+  EFI_DEBUG_IMAGE_INFO_NORMAL2  *NormalImage2;
 
   mDebugInfoTableHeader.UpdateStatus |= EFI_DEBUG_IMAGE_INFO_UPDATE_IN_PROGRESS;
 
   Table = mDebugInfoTableHeader.EfiDebugImageInfoTable;
 
   for (Index = 0; Index < mMaxTableEntries; Index++) {
-    if ((Table[Index].NormalImage != NULL) && (Table[Index].NormalImage->ImageHandle == ImageHandle)) {
-      //
-      // Found a match. Free up the record, then NULL the pointer to indicate the slot
-      // is free.
-      //
-      NormalImage = Table[Index].NormalImage;
-      //
-      // Decrease the number of EFI_DEBUG_IMAGE_INFO elements and set the mDebugInfoTable in modified status.
-      //
-      mDebugInfoTableHeader.UpdateStatus |= EFI_DEBUG_IMAGE_INFO_TABLE_MODIFIED;
-      mDebugInfoTableHeader.TableSize--;
-      Table[Index].NormalImage = NULL;
-
-      if (NormalImage->PdbPath != NULL) {
-        FreePool (NormalImage->PdbPath);
+    if (Table[Index].NormalImage2 != NULL) {
+      if (*Table[Index].ImageInfoType != EFI_DEBUG_IMAGE_INFO_TYPE_NORMAL2)
+      {
+        ASSERT (FALSE);
+        continue;
       }
 
-      CoreFreePool (NormalImage);
-      break;
+      if (Table[Index].NormalImage2->ImageHandle == ImageHandle) {
+        //
+        // Found a match. Free up the record, then NULL the pointer to indicate the slot
+        // is free.
+        //
+        NormalImage2 = Table[Index].NormalImage2;
+        //
+        // Decrease the number of EFI_DEBUG_IMAGE_INFO elements and set the mDebugInfoTable in modified status.
+        //
+        mDebugInfoTableHeader.UpdateStatus |= EFI_DEBUG_IMAGE_INFO_TABLE_MODIFIED;
+        mDebugInfoTableHeader.TableSize--;
+        Table[Index].NormalImage2 = NULL;
+
+        if (NormalImage2->PdbPath != NULL) {
+          FreePool (NormalImage2->PdbPath);
+        }
+
+        CoreFreePool (NormalImage2);
+        break;
+      }
     }
   }
 

--- a/MdeModulePkg/Core/PiSmmCore/DebugImageInfo.c
+++ b/MdeModulePkg/Core/PiSmmCore/DebugImageInfo.c
@@ -49,30 +49,29 @@ SmmInitializeDebugImageInfoTable (
 
 /**
   Adds a new DebugImageInfo structure to the DebugImageInfo Table.  Re-Allocates
-  the table if it's not large enough to accomidate another entry.
+  the table if it's not large enough to accommodate another entry.
 
-  @param  ImageInfoType  type of debug image information
   @param  LoadedImage    pointer to the loaded image protocol for the image being
                          loaded
   @param  ImageHandle    image handle for the image being loaded
+  @param  ImageContext   image context for the image being loaded
 
 **/
 VOID
 SmmNewDebugImageInfoEntry (
-  IN     UINT32                           ImageInfoType,
-  IN     EFI_LOADED_IMAGE_PROTOCOL        *LoadedImage,
-  IN     EFI_HANDLE                       ImageHandle,
-  IN OUT UEFI_IMAGE_LOADER_IMAGE_CONTEXT  *ImageContext
+  IN       EFI_LOADED_IMAGE_PROTOCOL        *LoadedImage,
+  IN       EFI_HANDLE                       ImageHandle,
+  IN CONST UEFI_IMAGE_LOADER_IMAGE_CONTEXT  *ImageContext
   )
 {
-  EFI_DEBUG_IMAGE_INFO        *Table;
-  EFI_DEBUG_IMAGE_INFO        *NewTable;
-  UINTN                       Index;
-  UINTN                       TableSize;
-  EFI_DEBUG_IMAGE_INFO_NORMAL *NormalImage;
-  RETURN_STATUS               Status;
-  CONST CHAR8                 *PdbPath;
-  UINT32                      PdbPathSize;
+  EFI_DEBUG_IMAGE_INFO          *Table;
+  EFI_DEBUG_IMAGE_INFO          *NewTable;
+  UINTN                         Index;
+  UINTN                         TableSize;
+  EFI_DEBUG_IMAGE_INFO_NORMAL2  *NormalImage2;
+  RETURN_STATUS                 Status;
+  CONST CHAR8                   *PdbPath;
+  UINT32                        PdbPathSize;
 
   //
   // Set the flag indicating that we're in the process of updating the table.
@@ -86,7 +85,7 @@ SmmNewDebugImageInfoEntry (
     // We still have empty entires in the Table, find the first empty entry.
     //
     Index = 0;
-    while (Table[Index].NormalImage != NULL) {
+    while (Table[Index].NormalImage2 != NULL) {
       Index++;
     }
     //
@@ -129,26 +128,26 @@ SmmNewDebugImageInfoEntry (
   //
   // Allocate data for new entry
   //
-  NormalImage = AllocateZeroPool (sizeof (EFI_DEBUG_IMAGE_INFO_NORMAL));
-  if (NormalImage != NULL) {
+  NormalImage2 = AllocateZeroPool (sizeof (EFI_DEBUG_IMAGE_INFO_NORMAL2));
+  if (NormalImage2 != NULL) {
     //
     // Update the entry
     //
-    NormalImage->ImageInfoType               = (UINT32) ImageInfoType;
-    NormalImage->LoadedImageProtocolInstance = LoadedImage;
-    NormalImage->ImageHandle                 = ImageHandle;
+    NormalImage2->ImageInfoType               = EFI_DEBUG_IMAGE_INFO_TYPE_NORMAL2;
+    NormalImage2->LoadedImageProtocolInstance = LoadedImage;
+    NormalImage2->ImageHandle                 = ImageHandle;
 
     Status = UefiImageGetSymbolsPath (ImageContext, &PdbPath, &PdbPathSize);
     if (!RETURN_ERROR (Status)) {
-      NormalImage->PdbPath = AllocateCopyPool (PdbPathSize, PdbPath);
+      NormalImage2->PdbPath = AllocateCopyPool (PdbPathSize, PdbPath);
     }
 
-    NormalImage->DebugBase = UefiImageLoaderGetDebugAddress (ImageContext);
+    NormalImage2->DebugBase = UefiImageLoaderGetDebugAddress (ImageContext);
     //
     // Increase the number of EFI_DEBUG_IMAGE_INFO elements and set the mDebugInfoTable in modified status.
     //
     mDebugInfoTableHeader.UpdateStatus |= EFI_DEBUG_IMAGE_INFO_TABLE_MODIFIED;
-    Table[Index].NormalImage = NormalImage;
+    Table[Index].NormalImage2 = NormalImage2;
     mDebugInfoTableHeader.TableSize++;
   }
   mDebugInfoTableHeader.UpdateStatus &= ~EFI_DEBUG_IMAGE_INFO_UPDATE_IN_PROGRESS;

--- a/MdeModulePkg/Core/PiSmmCore/Dispatcher.c
+++ b/MdeModulePkg/Core/PiSmmCore/Dispatcher.c
@@ -572,7 +572,6 @@ SmmLoadImage (
   // Register the image in the Debug Image Info Table if the attribute is set
   //
   SmmNewDebugImageInfoEntry (
-    EFI_DEBUG_IMAGE_INFO_TYPE_NORMAL,
     &DriverEntry->SmmLoadedImage,
     DriverEntry->SmmImageHandle,
     ImageContext

--- a/MdeModulePkg/Core/PiSmmCore/PiSmmCore.c
+++ b/MdeModulePkg/Core/PiSmmCore/PiSmmCore.c
@@ -859,7 +859,6 @@ SmmCoreInstallLoadedImage (
   //
   SmmInitializeDebugImageInfoTable ();
   SmmNewDebugImageInfoEntry (
-    EFI_DEBUG_IMAGE_INFO_TYPE_NORMAL,
     &mSmmCoreDriverEntry->SmmLoadedImage,
     mSmmCoreDriverEntry->SmmImageHandle,
     &gSmmCorePrivate->PiSmmCoreImageContext

--- a/MdeModulePkg/Core/PiSmmCore/PiSmmCore.h
+++ b/MdeModulePkg/Core/PiSmmCore/PiSmmCore.h
@@ -1374,20 +1374,19 @@ SmmInitializeDebugImageInfoTable (
 
 /**
   Adds a new DebugImageInfo structure to the DebugImageInfo Table.  Re-Allocates
-  the table if it's not large enough to accomidate another entry.
+  the table if it's not large enough to accommodate another entry.
 
-  @param  ImageInfoType  type of debug image information
   @param  LoadedImage    pointer to the loaded image protocol for the image being
                          loaded
   @param  ImageHandle    image handle for the image being loaded
+  @param  ImageContext   image context for the image being loaded
 
 **/
 VOID
 SmmNewDebugImageInfoEntry (
-  IN  UINT32                      ImageInfoType,
-  IN  EFI_LOADED_IMAGE_PROTOCOL   *LoadedImage,
-  IN  EFI_HANDLE                  ImageHandle,
-  IN  UEFI_IMAGE_LOADER_IMAGE_CONTEXT  *ImageContext
+  IN       EFI_LOADED_IMAGE_PROTOCOL        *LoadedImage,
+  IN       EFI_HANDLE                       ImageHandle,
+  IN CONST UEFI_IMAGE_LOADER_IMAGE_CONTEXT  *ImageContext
   );
 
 /**

--- a/MdeModulePkg/Universal/EbcDxe/EbcDebugger/EdbSymbol.c
+++ b/MdeModulePkg/Universal/EbcDxe/EbcDebugger/EdbSymbol.c
@@ -949,15 +949,15 @@ EdbPatchSymbolRVA (
   CandidateImageBase = NULL;
   ImageTable         = mDebuggerPrivate.DebugImageInfoTableHeader->EfiDebugImageInfoTable;
   for (ImageNumber = 0; ImageNumber < mDebuggerPrivate.DebugImageInfoTableHeader->TableSize; ImageNumber++) {
-    if (ImageTable[ImageNumber].NormalImage == NULL) {
+    if (ImageTable[ImageNumber].NormalImage2 == NULL) {
       continue;
     }
 
-    ImageBase = ImageTable[ImageNumber].NormalImage->LoadedImageProtocolInstance->ImageBase;
+    ImageBase = ImageTable[ImageNumber].NormalImage2->LoadedImageProtocolInstance->ImageBase;
     //
     // Get PDB path
     //
-    PdbPath   = ImageTable[ImageNumber].NormalImage->PdbPath;
+    PdbPath   = ImageTable[ImageNumber].NormalImage2->PdbPath;
     if (PdbPath == NULL) {
       continue;
     }

--- a/MdePkg/Include/Guid/DebugImageInfoTable.h
+++ b/MdePkg/Include/Guid/DebugImageInfoTable.h
@@ -25,7 +25,8 @@
 #define EFI_DEBUG_IMAGE_INFO_UPDATE_IN_PROGRESS  0x01
 #define EFI_DEBUG_IMAGE_INFO_TABLE_MODIFIED      0x02
 
-#define EFI_DEBUG_IMAGE_INFO_TYPE_NORMAL  0x01
+#define EFI_DEBUG_IMAGE_INFO_TYPE_NORMAL    0x01
+#define EFI_DEBUG_IMAGE_INFO_TYPE_NORMAL2   0x02
 
 typedef struct {
   UINT64                  Signature;          ///< A constant UINT64 that has the value EFI_SYSTEM_TABLE_SIGNATURE
@@ -35,8 +36,8 @@ typedef struct {
 
 typedef struct {
   ///
-  /// Indicates the type of image info structure. For PE32 EFI images,
-  /// this is set to EFI_DEBUG_IMAGE_INFO_TYPE_NORMAL.
+  /// When this debug image info structure is present, ImageInfoType is set
+  /// to EFI_DEBUG_IMAGE_INFO_TYPE_NORMAL indicating a loaded PE32 EFI image.
   ///
   UINT32                       ImageInfoType;
   ///
@@ -47,13 +48,50 @@ typedef struct {
   /// Indicates the image handle of the associated image.
   ///
   EFI_HANDLE                   ImageHandle;
-  CHAR8                      *PdbPath;
-  UINTN                        DebugBase;
 } EFI_DEBUG_IMAGE_INFO_NORMAL;
 
+typedef struct {
+  ///
+  /// When this debug image info structure is present, ImageInfoType is
+  /// set to EFI_DEBUG_IMAGE_INFO_TYPE_NORMAL2, indicating that PdbPath
+  /// and DebugBase fields are available for symbolication. The format
+  /// of the loaded image is not specified and may or may not be PE.
+  ///
+  UINT32                       ImageInfoType;
+  ///
+  /// A pointer to an instance of the loaded image protocol for the associated image.
+  ///
+  EFI_LOADED_IMAGE_PROTOCOL    *LoadedImageProtocolInstance;
+  ///
+  /// Indicates the image handle of the associated image.
+  ///
+  EFI_HANDLE                   ImageHandle;
+  ///
+  /// Symbol file path for debug symbolication.
+  ///
+  CHAR8                        *PdbPath;
+  ///
+  /// Image base address for debug symbolication.
+  ///
+  UINTN                        DebugBase;
+} EFI_DEBUG_IMAGE_INFO_NORMAL2;
+
 typedef union {
-  UINT32                         *ImageInfoType;
-  EFI_DEBUG_IMAGE_INFO_NORMAL    *NormalImage;
+  ///
+  /// Indicates the type of image info structure which is present. For
+  /// PE32 EFI images loaded with the old image loader, this is set to
+  /// EFI_DEBUG_IMAGE_INFO_TYPE_NORMAL. For all images loaded with the new
+  /// image loader, this is set to EFI_DEBUG_IMAGE_INFO_TYPE_NORMAL2.
+  ///
+  UINT32                            *ImageInfoType;
+  ///
+  /// Present when ImageInfoType is EFI_DEBUG_IMAGE_INFO_TYPE_NORMAL.
+  ///
+  EFI_DEBUG_IMAGE_INFO_NORMAL       *NormalImage;
+  ///
+  /// Present when ImageInfoType is EFI_DEBUG_IMAGE_INFO_TYPE_NORMAL2.
+  ///
+  EFI_DEBUG_IMAGE_INFO_NORMAL2      *NormalImage2;
 } EFI_DEBUG_IMAGE_INFO;
 
 typedef struct {

--- a/MdePkg/Include/IndustryStandard/PeImage.h
+++ b/MdePkg/Include/IndustryStandard/PeImage.h
@@ -233,7 +233,7 @@ typedef struct {
   UINT64                      SizeOfHeapCommit;
   UINT32                      LoaderFlags;
   UINT32                      NumberOfRvaAndSizes;
-  EFI_IMAGE_DATA_DIRECTORY  DataDirectory[EFI_IMAGE_NUMBER_OF_DIRECTORY_ENTRIES];
+  EFI_IMAGE_DATA_DIRECTORY    DataDirectory[EFI_IMAGE_NUMBER_OF_DIRECTORY_ENTRIES];
 } EFI_IMAGE_OPTIONAL_HEADER64;
 
 

--- a/MdePkg/Include/IndustryStandard/UeImage.h
+++ b/MdePkg/Include/IndustryStandard/UeImage.h
@@ -407,11 +407,11 @@ typedef struct {
   (OFFSET_OF (UE_DEBUG_TABLE, SymbolsPath) + 1U)
 
 /**
-  Retrieves the UE symbols address offset in SegmentAlignment-units.
+  Retrieves the UE symbol address subtrahend in SegmentAlignment-units.
 
   @param[in] ImageInfo  The UE debug table image information.
 **/
-#define UE_DEBUG_TABLE_IMAGE_INFO_SYM_OFFSET_FACTOR(ImageInfo)  \
+#define UE_DEBUG_TABLE_IMAGE_INFO_SYM_SUBTRAHEND_FACTOR(ImageInfo)  \
   ((UINT8)((ImageInfo) & 0x03U))
 
 /**

--- a/MdePkg/Library/BaseUeImageLib/UeImageLib.c
+++ b/MdePkg/Library/BaseUeImageLib/UeImageLib.c
@@ -1231,21 +1231,21 @@ UeLoaderGetImageDebugAddress (
   RETURN_STATUS         Status;
   CONST UE_DEBUG_TABLE  *DebugTable;
   UINT8                 SymOffsetFactor;
-  UINT32                SymOffsetAddend;
+  UINT32                SymOffsetSubtrahend;
 
   ASSERT (Context != NULL);
 
-  SymOffsetAddend = 0;
+  SymOffsetSubtrahend = 0;
 
   Status = InternalGetDebugTable (Context, &DebugTable);
   if (!RETURN_ERROR (Status)) {
-    SymOffsetFactor = UE_DEBUG_TABLE_IMAGE_INFO_SYM_OFFSET_FACTOR (
+    SymOffsetFactor = UE_DEBUG_TABLE_IMAGE_INFO_SYM_SUBTRAHEND_FACTOR (
                         DebugTable->ImageInfo
                         );
-    SymOffsetAddend = (UINT32)SymOffsetFactor * Context->SegmentAlignment;
+    SymOffsetSubtrahend = (UINT32)SymOffsetFactor * Context->SegmentAlignment;
   }
 
-  return UeLoaderGetImageAddress (Context) + SymOffsetAddend;
+  return UeLoaderGetImageAddress (Context) - SymOffsetSubtrahend;
 }
 
 RETURN_STATUS

--- a/ShellPkg/DynamicCommand/DpDynamicCommand/DpUtilities.c
+++ b/ShellPkg/DynamicCommand/DpDynamicCommand/DpUtilities.c
@@ -211,11 +211,11 @@ GetImagePdb (
   }
 
   for (Entry = 0; Entry < DebugTableHeader->TableSize; Entry++, DebugTable++) {
-    if (DebugTable->NormalImage != NULL) {
-      if ((DebugTable->NormalImage->ImageInfoType == EFI_DEBUG_IMAGE_INFO_TYPE_NORMAL) &&
-          (DebugTable->NormalImage->LoadedImageProtocolInstance != NULL)) {
-        if (ImageBase == DebugTable->NormalImage->LoadedImageProtocolInstance->ImageBase) {
-          return DebugTable->NormalImage->PdbPath;
+    if (DebugTable->NormalImage2 != NULL) {
+      if ((DebugTable->NormalImage2->ImageInfoType == EFI_DEBUG_IMAGE_INFO_TYPE_NORMAL2) &&
+          (DebugTable->NormalImage2->LoadedImageProtocolInstance != NULL)) {
+        if (ImageBase == DebugTable->NormalImage2->LoadedImageProtocolInstance->ImageBase) {
+          return DebugTable->NormalImage2->PdbPath;
         }
       }
     }

--- a/UefiCpuPkg/Library/CpuExceptionHandlerLib/DxeException.c
+++ b/UefiCpuPkg/Library/CpuExceptionHandlerLib/DxeException.c
@@ -148,9 +148,9 @@ GetImageInfoByIp (
   IN  UINTN        CurrentEip
   )
 {
-  EFI_STATUS                        Status;
-  UINT32                            Index;
-  CONST EFI_DEBUG_IMAGE_INFO_NORMAL *NormalImage;
+  EFI_STATUS                          Status;
+  UINT32                              Index;
+  CONST EFI_DEBUG_IMAGE_INFO_NORMAL2  *NormalImage2;
 
   if (mDebugImageInfoTable == NULL) {
     Status = EfiGetSystemConfigurationTable (
@@ -170,19 +170,19 @@ GetImageInfoByIp (
       continue;
     }
 
-    if (*mDebugImageInfoTable->EfiDebugImageInfoTable[Index].ImageInfoType != EFI_DEBUG_IMAGE_INFO_TYPE_NORMAL) {
+    if (*mDebugImageInfoTable->EfiDebugImageInfoTable[Index].ImageInfoType != EFI_DEBUG_IMAGE_INFO_TYPE_NORMAL2) {
       continue;
     }
 
-    NormalImage = mDebugImageInfoTable->EfiDebugImageInfoTable[Index].NormalImage;
+    NormalImage2 = mDebugImageInfoTable->EfiDebugImageInfoTable[Index].NormalImage2;
 
-    ASSERT (NormalImage->LoadedImageProtocolInstance != NULL);
+    ASSERT (NormalImage2->LoadedImageProtocolInstance != NULL);
 
-    if (CurrentEip >= (UINTN) NormalImage->LoadedImageProtocolInstance->ImageBase &&
-        CurrentEip < (UINTN) NormalImage->LoadedImageProtocolInstance->ImageBase + NormalImage->LoadedImageProtocolInstance->ImageSize) {
-      *ImageBase   = (UINTN) NormalImage->LoadedImageProtocolInstance->ImageBase;
-      *DebugBase   = NormalImage->DebugBase;
-      *SymbolsPath = NormalImage->PdbPath;
+    if (CurrentEip >= (UINTN) NormalImage2->LoadedImageProtocolInstance->ImageBase &&
+        CurrentEip < (UINTN) NormalImage2->LoadedImageProtocolInstance->ImageBase + NormalImage2->LoadedImageProtocolInstance->ImageSize) {
+      *ImageBase   = (UINTN) NormalImage2->LoadedImageProtocolInstance->ImageBase;
+      *DebugBase   = NormalImage2->DebugBase;
+      *SymbolsPath = NormalImage2->PdbPath;
       return TRUE;
     }
   }

--- a/UefiCpuPkg/Library/CpuExceptionHandlerLib/SmmException.c
+++ b/UefiCpuPkg/Library/CpuExceptionHandlerLib/SmmException.c
@@ -155,9 +155,9 @@ GetImageInfoByIp (
   IN  UINTN        CurrentEip
   )
 {
-  EFI_STATUS                        Status;
-  UINT32                            Index;
-  CONST EFI_DEBUG_IMAGE_INFO_NORMAL *NormalImage;
+  EFI_STATUS                          Status;
+  UINT32                              Index;
+  CONST EFI_DEBUG_IMAGE_INFO_NORMAL2  *NormalImage2;
 
   if (mDebugImageInfoTableHeader == NULL) {
     Status = InternalGetSystemConfigurationTable (
@@ -177,19 +177,19 @@ GetImageInfoByIp (
       continue;
     }
 
-    if (*mDebugImageInfoTableHeader->EfiDebugImageInfoTable[Index].ImageInfoType != EFI_DEBUG_IMAGE_INFO_TYPE_NORMAL) {
+    if (*mDebugImageInfoTableHeader->EfiDebugImageInfoTable[Index].ImageInfoType != EFI_DEBUG_IMAGE_INFO_TYPE_NORMAL2) {
       continue;
     }
 
-    NormalImage = mDebugImageInfoTableHeader->EfiDebugImageInfoTable[Index].NormalImage;
+    NormalImage2 = mDebugImageInfoTableHeader->EfiDebugImageInfoTable[Index].NormalImage2;
 
-    ASSERT (NormalImage->LoadedImageProtocolInstance != NULL);
+    ASSERT (NormalImage2->LoadedImageProtocolInstance != NULL);
 
-    if (CurrentEip >= (UINTN) NormalImage->LoadedImageProtocolInstance->ImageBase &&
-        CurrentEip < (UINTN) NormalImage->LoadedImageProtocolInstance->ImageBase + NormalImage->LoadedImageProtocolInstance->ImageSize) {
-      *ImageBase   = (UINTN) NormalImage->LoadedImageProtocolInstance->ImageBase;
-      *DebugBase   = NormalImage->DebugBase;
-      *SymbolsPath = NormalImage->PdbPath;
+    if (CurrentEip >= (UINTN) NormalImage2->LoadedImageProtocolInstance->ImageBase &&
+        CurrentEip < (UINTN) NormalImage2->LoadedImageProtocolInstance->ImageBase + NormalImage2->LoadedImageProtocolInstance->ImageSize) {
+      *ImageBase   = (UINTN) NormalImage2->LoadedImageProtocolInstance->ImageBase;
+      *DebugBase   = NormalImage2->DebugBase;
+      *SymbolsPath = NormalImage2->PdbPath;
       return TRUE;
     }
   }

--- a/UefiCpuPkg/PiSmmCpuDxeSmm/PiSmmCpuDxeSmm.c
+++ b/UefiCpuPkg/PiSmmCpuDxeSmm/PiSmmCpuDxeSmm.c
@@ -196,14 +196,14 @@ SmmGetSystemConfigurationTable (
 CONST EFI_DEBUG_IMAGE_INFO_TABLE_HEADER *mDebugImageInfoTableHeader = NULL;
 
 // FIXME:
-CONST EFI_DEBUG_IMAGE_INFO_NORMAL *
+CONST EFI_DEBUG_IMAGE_INFO_NORMAL2 *
 InternalLocateImage (
   IN  UINTN              CurrentEip
   )
 {
   EFI_STATUS                        Status;
   UINT32                            Index;
-  CONST EFI_DEBUG_IMAGE_INFO_NORMAL *NormalImage;
+  CONST EFI_DEBUG_IMAGE_INFO_NORMAL2 *NormalImage2;
 
   if (mDebugImageInfoTableHeader == NULL) {
     Status = SmmGetSystemConfigurationTable (
@@ -223,17 +223,17 @@ InternalLocateImage (
       continue;
     }
 
-    if (*mDebugImageInfoTableHeader->EfiDebugImageInfoTable[Index].ImageInfoType != EFI_DEBUG_IMAGE_INFO_TYPE_NORMAL) {
+    if (*mDebugImageInfoTableHeader->EfiDebugImageInfoTable[Index].ImageInfoType != EFI_DEBUG_IMAGE_INFO_TYPE_NORMAL2) {
       continue;
     }
 
-    NormalImage = mDebugImageInfoTableHeader->EfiDebugImageInfoTable[Index].NormalImage;
+    NormalImage2 = mDebugImageInfoTableHeader->EfiDebugImageInfoTable[Index].NormalImage2;
 
-    ASSERT (NormalImage->LoadedImageProtocolInstance != NULL);
+    ASSERT (NormalImage2->LoadedImageProtocolInstance != NULL);
 
-    if (CurrentEip >= (UINTN) NormalImage->LoadedImageProtocolInstance->ImageBase &&
-        CurrentEip < (UINTN) NormalImage->LoadedImageProtocolInstance->ImageBase + NormalImage->LoadedImageProtocolInstance->ImageSize) {
-      return NormalImage;
+    if (CurrentEip >= (UINTN) NormalImage2->LoadedImageProtocolInstance->ImageBase &&
+        CurrentEip < (UINTN) NormalImage2->LoadedImageProtocolInstance->ImageBase + NormalImage2->LoadedImageProtocolInstance->ImageSize) {
+      return NormalImage2;
     }
   }
 
@@ -251,17 +251,17 @@ DumpModuleInfoByIp (
   IN  UINTN  CallerIpAddress
   )
 {
-  CONST EFI_DEBUG_IMAGE_INFO_NORMAL *NormalImage;
+  CONST EFI_DEBUG_IMAGE_INFO_NORMAL2  *NormalImage2;
 
-  NormalImage = InternalLocateImage (CallerIpAddress);
+  NormalImage2 = InternalLocateImage (CallerIpAddress);
 
   //
   // Find Image Base
   //
-  if (NormalImage != NULL) {
+  if (NormalImage2 != NULL) {
     DEBUG ((DEBUG_ERROR, "It is invoked from the instruction before IP(0x%p)", (VOID *)CallerIpAddress));
-    if (NormalImage->PdbPath!= NULL) {
-      DEBUG ((DEBUG_ERROR, " in module (%a)\n", NormalImage->PdbPath));
+    if (NormalImage2->PdbPath!= NULL) {
+      DEBUG ((DEBUG_ERROR, " in module (%a)\n", NormalImage2->PdbPath));
     }
   }
 }


### PR DESCRIPTION
The intention here is to enable old tools encountering the new standard format to understand that they don't understand the layout.

This will break old tools in situations where they could have worked, i.e. where what is loaded is in fact a PE, but it seems preferable to allow new tools, which are aware of the new structure fields, to reliably detect and access these whenever they are present.