### PR TITLE
DebugLib: Simplify DEBUG and ASSERT macros used when MDEPKG_NDEBUG is defined

### DIFF
--- a/MdePkg/Include/Library/DebugLib.h
+++ b/MdePkg/Include/Library/DebugLib.h
@@ -408,7 +408,7 @@ UnitTestDebugAssert (
 #else
 #define ASSERT(Expression)       \
     do {                           \
-      if ((FALSE)) {               \
+      if (FALSE) {                 \
         (VOID) (Expression);       \
       }                            \
     } while (FALSE)
@@ -433,18 +433,13 @@ UnitTestDebugAssert (
         _DEBUG (Expression);       \
       }                            \
     } while (FALSE)
-#elif defined (__GNUC__) || defined (__clang__)
-#define DEBUG(Expression)                                \
-    do {                                                   \
-      _Pragma("GCC diagnostic push")                       \
-      _Pragma("GCC diagnostic ignored \"-Wunused-value\"") \
-      if ((FALSE)) {                                       \
-        (VOID) Expression;                                 \
-      }                                                    \
-      _Pragma("GCC diagnostic pop")                        \
-    } while (FALSE)
 #else
-#define DEBUG(Expression)
+#define DEBUG(Expression)        \
+    do {                           \
+      if (FALSE) {                 \
+        _DEBUG (Expression);       \
+      }                            \
+    } while (FALSE)
 #endif
 
 /**
@@ -472,7 +467,7 @@ UnitTestDebugAssert (
 #else
 #define ASSERT_EFI_ERROR(StatusParameter)                                             \
     do {                                                                                \
-      if ((FALSE)) {                                                                    \
+      if (FALSE) {                                                                      \
         (VOID) (StatusParameter);                                                       \
       }                                                                                 \
     } while (FALSE)
@@ -504,7 +499,7 @@ UnitTestDebugAssert (
 #else
 #define ASSERT_RETURN_ERROR(StatusParameter)                          \
     do {                                                                \
-      if ((FALSE)) {                                                    \
+      if (FALSE) {                                                      \
         (VOID) (StatusParameter);                                       \
       }                                                                 \
     } while (FALSE)


### PR DESCRIPTION
The variants provided when MDEPKG_NDEBUG is defined will be optimised away in RELEASE builds, but by referencing the argument (or argument list, in the case of DEBUG) avoid unused variable errors from valid debug code, for example when STATIC variables are used only in DEBUG statements.