### PR TITLE
OvmfPkg: Update LINUX_LOADER PcdImageProtectionPolicy to allow unaligned user images

### DIFF
--- a/OvmfPkg/IntelTdx/IntelTdxX64.dsc
+++ b/OvmfPkg/IntelTdx/IntelTdxX64.dsc
@@ -485,6 +485,7 @@
     # Allow execution of EfiReservedMemoryType, EfiConventionalMemory, EfiBootServicesData and EfiLoaderData memory regions.
     gEfiMdeModulePkgTokenSpaceGuid.PcdDxeNxMemoryProtectionPolicy|0xFFFFFFFFFFFFFF40
     gEfiMdePkgTokenSpaceGuid.PcdImageLoaderAllowMisalignedOffset|TRUE
+    gEfiMdePkgTokenSpaceGuid.PcdImageProtectionPolicy|0x00000003
   !else
     # Allow execution of EfiConventionalMemory and EfiBootServicesData memory regions.
     gEfiMdeModulePkgTokenSpaceGuid.PcdDxeNxMemoryProtectionPolicy|0xFFFFFFFFFFFFFF45

--- a/OvmfPkg/OvmfPkgIa32.dsc
+++ b/OvmfPkg/OvmfPkgIa32.dsc
@@ -592,6 +592,7 @@
     # Allow execution of EfiReservedMemoryType, EfiConventionalMemory, EfiBootServicesData and EfiLoaderData memory regions.
     gEfiMdeModulePkgTokenSpaceGuid.PcdDxeNxMemoryProtectionPolicy|0xFFFFFFFFFFFFFF40
     gEfiMdePkgTokenSpaceGuid.PcdImageLoaderAllowMisalignedOffset|TRUE
+    gEfiMdePkgTokenSpaceGuid.PcdImageProtectionPolicy|0x00000003
   !elseif $(WINDOWS_10_IA32) == TRUE
     # Allow execution of EfiReservedMemoryType, EfiConventionalMemory, EfiBootServicesData and EfiRuntimeServicesData memory regions.
     gEfiMdeModulePkgTokenSpaceGuid.PcdDxeNxMemoryProtectionPolicy|0xFFFFFFFFFFFFFF04

--- a/OvmfPkg/OvmfPkgIa32X64.dsc
+++ b/OvmfPkg/OvmfPkgIa32X64.dsc
@@ -607,6 +607,7 @@
     # Allow execution of EfiReservedMemoryType, EfiConventionalMemory, EfiBootServicesData and EfiLoaderData memory regions.
     gEfiMdeModulePkgTokenSpaceGuid.PcdDxeNxMemoryProtectionPolicy|0xFFFFFFFFFFFFFF40
     gEfiMdePkgTokenSpaceGuid.PcdImageLoaderAllowMisalignedOffset|TRUE
+    gEfiMdePkgTokenSpaceGuid.PcdImageProtectionPolicy|0x00000003
   !endif
 
 ################################################################################

--- a/OvmfPkg/OvmfPkgX64.dsc
+++ b/OvmfPkg/OvmfPkgX64.dsc
@@ -623,6 +623,7 @@
     # Allow execution of EfiReservedMemoryType, EfiConventionalMemory, EfiBootServicesData and EfiLoaderData memory regions.
     gEfiMdeModulePkgTokenSpaceGuid.PcdDxeNxMemoryProtectionPolicy|0xFFFFFFFFFFFFFF40
     gEfiMdePkgTokenSpaceGuid.PcdImageLoaderAllowMisalignedOffset|TRUE
+    gEfiMdePkgTokenSpaceGuid.PcdImageProtectionPolicy|0x00000003
   !endif
 
 ################################################################################


### PR DESCRIPTION
Required in some current distros, e.g. SliTaz https://slitaz.org/

```
$ objdump -p -h ~/Public/bootx64.efi 

/Users/mjsbeaton/Public/bootx64.efi:	file format coff-x86-64
Characteristics 0x206
	executable
	line numbers stripped
	debugging information removed

.
.
.
SectionAlignment        00000020
.
.
.
NumberOfRvaAndSizes     00000006

.
.
.

Sections:
Idx Name          Size     VMA              Type
  0 .setup        000035e0 0000000000000200 TEXT
  1 .reloc        00000020 00000000000037e0 DATA
  2 .text         003cf010 0000000000003800 TEXT
  3 .bss          00000000 00000000003d2810 BSS
$ 
```
[bootx64.zip](https://github.com/acidanthera/audk/files/14591909/bootx64.zip)

