### PR TITLE
BaseTools: Enable symbolic debugging with LTO in XCODE toolchain

### DIFF
--- a/BaseTools/Conf/build_rule.template
+++ b/BaseTools/Conf/build_rule.template
@@ -307,7 +307,7 @@
         "$(DLINK)" -o ${dst} $(DLINK_FLAGS) -Wl,--start-group,@$(STATIC_LIBRARY_FILES_LIST),--end-group $(CC_FLAGS) $(DLINK2_FLAGS)
 
     <Command.XCODE>
-        "$(DLINK)" $(DLINK_FLAGS) -o ${dst} $(DLINK_SPATH) -filelist $(STATIC_LIBRARY_FILES_LIST)  $(DLINK2_FLAGS)
+        "$(DLINK)" $(DLINK_FLAGS) -o ${dst} -object_path_lto ${dst}.lto $(DLINK_SPATH) -filelist $(STATIC_LIBRARY_FILES_LIST)  $(DLINK2_FLAGS)
 
 
 [Static-Library-File.SEC.AARCH64, Static-Library-File.PEI_CORE.AARCH64, Static-Library-File.PEIM.AARCH64,Static-Library-File.SEC.ARM, Static-Library-File.PEI_CORE.ARM, Static-Library-File.PEIM.ARM]
@@ -340,7 +340,7 @@
         "$(DLINK)" $(DLINK_FLAGS) -Wl,--start-group,@$(STATIC_LIBRARY_FILES_LIST),--end-group $(CC_FLAGS) $(DLINK2_FLAGS)
 
     <Command.XCODE>
-        "$(DLINK)" -o ${dst} $(DLINK_FLAGS)  $(DLINK_SPATH) -filelist $(STATIC_LIBRARY_FILES_LIST)  $(DLINK2_FLAGS)
+        "$(DLINK)" -o ${dst} -object_path_lto ${dst}.lto $(DLINK_FLAGS)  $(DLINK_SPATH) -filelist $(STATIC_LIBRARY_FILES_LIST)  $(DLINK2_FLAGS)
 
 
 [Dynamic-Library-File]


### PR DESCRIPTION
This is a bit of a hack - but it does work, and generates harmless files when not needed.

The reason for adding it is that currently OpenDuetPkg will not start in qemu without -flto -Os (for reasons currently unknown).

With this fix, and the DxeCore HOB fix, it is now possible to have true symbolic debugging into OpenDuet, which IMO is a) very useful, and b) perfectly usable even with these strong optimisations applied - and certainly far better than none at all.