### PR TITLE
NetworkPkg: Do not enforce secure RNG

### DIFF
--- a/NetworkPkg/NetworkPkg.dec
+++ b/NetworkPkg/NetworkPkg.dec
@@ -135,7 +135,7 @@
   # TRUE  - Enforce the use of Secure UEFI spec defined RNG algorithms.
   # FALSE - Do not enforce and depend on the default implementation of RNG algorithm from the provider.
   # @Prompt Enforce the use of Secure UEFI spec defined RNG algorithms.
-  gEfiNetworkPkgTokenSpaceGuid.PcdEnforceSecureRngAlgorithms|TRUE|BOOLEAN|0x1000000D
+  gEfiNetworkPkgTokenSpaceGuid.PcdEnforceSecureRngAlgorithms|FALSE|BOOLEAN|0x1000000D
 
 [PcdsFixedAtBuild, PcdsPatchableInModule, PcdsDynamic, PcdsDynamicEx]
   ## IPv6 DHCP Unique Identifier (DUID) Type configuration (From RFCs 3315 and 6355).


### PR DESCRIPTION
Since edk2-stable202405 we require EFI_RNG_PROTOCOL (RNG=Random Number Generator) for various network stack drivers.

We can't avoid requiring the protocol, but we do not want to insist that a secure algorithm is present. If we do leave the Pcd TRUE, DxeNetLib logs at level DEBUG_ERROR when using OVMF `-device virtio-rng-pci` (even though the supported RNG protocols check eventually succeeds), and it may do the same with the available Rng in various firmware too (and there, the RN generation may not succeed, if none of the required algos are present; even if some other RNG algorithm is present).

Believe this is probably a change we want to make, for ease of use of OVMF (as above) and our shipped network drivers (which need to run on any firmware).

**EDIT**: This change is no longer required for ease of use of OVMF - the 202408 EDK 2 commit mentioned below fixes that; but I think we still want to be able to use whatever the existing RNG is (whether or not is is secure) with our network stack on other firmware - probably? Perhaps not - in which case maybe forget this change (i.e. if a user's firmware has only RNG considered insecure, then they will need to load RngDxe.efi).

**EDIT**: Obviously if compiling custom firmware which is supposed to include a secure algorithm, this value can and should be switched back to its previous default. (Note that in that case, it makes sense to downgrade [this line](https://github.com/acidanthera/audk/blob/master/NetworkPkg/Library/DxeNetLib/DxeNetLib.c#L954) from DEBUG_ERROR, a change which on checking now I find has already been introduced in edk2-stable202408 https://github.com/tianocore/edk2/commit/6862b9d538d96363635677198899e1669e591259, see also https://github.com/tianocore/edk2/pull/6171.)