### PR TITLE
MdePkg/BaseOverflowLib: Support BASE_ALIGNAS on VS2019

### DIFF
--- a/MdePkg/Include/Library/BaseOverflowLib.h
+++ b/MdePkg/Include/Library/BaseOverflowLib.h
@@ -32,9 +32,11 @@ WITHOUT WARRANTIES OR REPRESENTATIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED.
 #define BASE_TYPE_ALIGNED(Type, Ptr)  (BASE_POT_ALIGNED (BASE_ALIGNOF (Type), Ptr))
 
 //
-// Force member alignment for the structure.
+// Force alignment for structure member or variable definition.
 //
-#if (defined (__STDC__) && __STDC_VERSION__ >= 201112L) || defined (__GNUC__) || defined (__clang__)
+#if defined (_MSC_VER)
+#define BASE_ALIGNAS(Alignment)  __declspec(align(Alignment))
+#elif (defined (__STDC__) && __STDC_VERSION__ >= 201112L) || defined (__GNUC__) || defined (__clang__)
 #define BASE_ALIGNAS(Alignment)  _Alignas(Alignment)
 #else
 #define BASE_ALIGNAS(Alignment)


### PR DESCRIPTION
Note: this must be combined with flag /wd4324 added to MSFT:*_CC_FLAGS to avoid spurious warnings when the macro is working as intended.

Update comment since alignment in all architectures can be used to align structure member or variable definition.