### PR TITLE
Added UserEvent into Makefile for Windows

### DIFF
--- a/BaseTools/ImageTool/Makefile
+++ b/BaseTools/ImageTool/Makefile
@@ -35,7 +35,7 @@ USER = $(OC_USER)\User\Library
 OBJECTS = $(OBJECTS) {$(BASE)}SafeString.obj String.obj SwapBytes16.obj SwapBytes32.obj CpuDeadLoop.obj CheckSum.obj QuickSort.obj LinkedList.obj
 OBJECTS = $(OBJECTS) {$(OUT)}DebugLib.obj {$(PRIN)}PrintLib.obj PrintLibInternal.obj {$(ERRO)}BaseDebugPrintErrorLevelLib.obj
 OBJECTS = $(OBJECTS) {$(UIMG)}UefiImageLib.obj UeSupport.obj PeSupport.obj CommonSupport.obj
-OBJECTS = $(OBJECTS) {$(USER)}UserFile.obj UserBaseMemoryLib.obj UserMath.obj UserPcd.obj UserMisc.obj UserGlobalVar.obj UserBootServices.obj
+OBJECTS = $(OBJECTS) {$(USER)}UserFile.obj UserBaseMemoryLib.obj UserMath.obj UserPcd.obj UserMisc.obj UserGlobalVar.obj UserEvent.obj UserBootServices.obj
 OBJECTS = $(OBJECTS) {$(BMPN)}BaseMemoryProfileLibNull.obj {$(CMEM)}CommonMemoryAllocationLib.obj {$(CMEM)}CommonMemoryAllocationLibEx.obj
 
 INC = -I . -I $(OC_USER)\User\Include -I $(OC_USER)\Include\Acidanthera

--- a/BaseTools/MicroTool/Makefile
+++ b/BaseTools/MicroTool/Makefile
@@ -26,7 +26,7 @@ CMEM = $(UDK_PATH)\MdeModulePkg\Library\CommonMemoryAllocationLib
 USER = $(OC_USER)\User\Library
 OBJECTS = $(OBJECTS) {$(BASE)}SafeString.obj String.obj SwapBytes16.obj SwapBytes32.obj CpuDeadLoop.obj CheckSum.obj
 OBJECTS = $(OBJECTS) {$(OUT)}DebugLib.obj {$(PRIN)}PrintLib.obj PrintLibInternal.obj {$(ERRO)}BaseDebugPrintErrorLevelLib.obj
-OBJECTS = $(OBJECTS) {$(USER)}UserFile.obj UserBaseMemoryLib.obj UserMath.obj UserPcd.obj UserMisc.obj UserGlobalVar.obj UserBootServices.obj
+OBJECTS = $(OBJECTS) {$(USER)}UserFile.obj UserBaseMemoryLib.obj UserMath.obj UserPcd.obj UserMisc.obj UserGlobalVar.obj UserEvent.obj UserBootServices.obj
 OBJECTS = $(OBJECTS) {$(BMPN)}BaseMemoryProfileLibNull.obj {$(CMEM)}CommonMemoryAllocationLib.obj {$(CMEM)}CommonMemoryAllocationLibEx.obj
 
 INC = -I . -I $(OC_USER)\User\Include -I $(OC_USER)\Include\Acidanthera


### PR DESCRIPTION
# Description

Support for EFI Events has been added to userspace in the OpenCorePkg project. To pass CI for VS2019, the UserEvent file needs to be added to Makefiles in this commit.

Linked PR: https://github.com/acidanthera/OpenCorePkg/pull/577

## Integration Instructions

N/A
